### PR TITLE
expose 'readOnly' props

### DIFF
--- a/examples/controlled.js
+++ b/examples/controlled.js
@@ -14,6 +14,7 @@ const MentionEditor = React.createClass({
       suggestions: originSuggestions,
       defaultValue: toEditorState('hello @afc163'),
       editorState: EditorState.createEmpty(),
+      readOnly: false,
     };
   },
   onSearchChange(value) {
@@ -35,10 +36,16 @@ const MentionEditor = React.createClass({
       editorState: this.state.defaultValue,
     });
   },
+  toggleReadOnly() {
+    this.setState({
+      readOnly: !this.state.readOnly,
+    });
+  },
   render() {
     const { suggestions, editorState } = this.state;
     return (<div>
       <button onClick={this.reset}> reset </button>
+      <button onClick={this.toggleReadOnly}> toggleReadOnly </button>
       <Mention
         style={{ width: 300, height: 200 }}
         ref="mention"
@@ -46,7 +53,9 @@ const MentionEditor = React.createClass({
         defaultValue={this.state.defaultValue}
         value={editorState}
         onChange={this.onChange}
-        suggestions={suggestions} prefix="@"
+        suggestions={suggestions}
+        prefix="@"
+        readOnly={this.state.readOnly}
       /></div>);
   },
 });

--- a/src/component/Mention.react.jsx
+++ b/src/component/Mention.react.jsx
@@ -32,6 +32,7 @@ class Mention extends React.Component {
     getSuggestionContainer: React.PropTypes.func,
     noRedup: React.PropTypes.bool,
     mentionStyle: React.PropTypes.object,
+    readOnly: React.PropTypes.bool,
   }
 
   constructor(props) {
@@ -77,7 +78,7 @@ class Mention extends React.Component {
     if (this.props.onChange) {
       this.props.onChange(
         EditorState.createWithContent(
-          editorState.getCurrentContent(), 
+          editorState.getCurrentContent(),
           decorator
         ), exportContent(editorState));
     }
@@ -107,7 +108,7 @@ class Mention extends React.Component {
     const {
       prefixCls, style, tag, multiLines,
       suggestionStyle, placeholder, defaultValue, className, notFoundContent,
-      getSuggestionContainer,
+      getSuggestionContainer, readOnly,
     } = this.props;
     const { suggestions } = this.state;
     const { Suggestions } = this;
@@ -130,6 +131,7 @@ class Mention extends React.Component {
         onFocus={this.onFocus}
         onBlur={this.onBlur}
         onChange={this.onEditorChange}
+        readOnly={readOnly}
         {...editorCoreProps}
       >
         <Suggestions
@@ -163,6 +165,7 @@ Mention.defaultProps = {
   notFoundContent: '无法找到',
   position: 'absolute',
   mentionStyle: {},
+  readOnly: false,
 };
 
 export default Mention;


### PR DESCRIPTION
To fix https://github.com/ant-design/ant-design/issues/5175

Related PR: https://github.com/react-component/editor-core/pull/4