### PR TITLE
Adds missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
     "rc-animate": "^2.3.0",
     "rc-editor-core": "~0.8.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  },
   "jest": {
     "verbose": true,
     "collectCoverageFrom": [


### PR DESCRIPTION
The `draft-js` package has peer dependencies on `react` and `react-dom`, which means that `editor-mention` also depends on them.