### PR TITLE
use the element type cause the some warnings

### DIFF
--- a/src/component/Mention.react.jsx
+++ b/src/component/Mention.react.jsx
@@ -15,7 +15,7 @@ class Mention extends React.Component {
       [PropTypes.string, PropTypes.arrayOf(PropTypes.string)]
     ),
     prefixCls: PropTypes.string,
-    tag: PropTypes.element,
+    tag: PropTypes.func,
     style: PropTypes.object,
     className: PropTypes.string,
     onSearchChange: PropTypes.func,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22249411/49007547-b3e82200-f1a6-11e8-900e-caf920951b14.png)

![image](https://user-images.githubusercontent.com/22249411/49007580-c9f5e280-f1a6-11e8-98ff-26496cfedd8b.png)

but now changed:
![image](https://user-images.githubusercontent.com/22249411/49007630-e5f98400-f1a6-11e8-9aa4-ea02a1e13b05.png)
![image](https://user-images.githubusercontent.com/22249411/49007641-e98d0b00-f1a6-11e8-8472-f4ce01e33487.png)

that writing way can't passed the props.